### PR TITLE
Update env var name to be less ambiguous

### DIFF
--- a/lib/phantomjs/platform.rb
+++ b/lib/phantomjs/platform.rb
@@ -98,7 +98,7 @@ module Phantomjs
         end
 
         def package_url
-          ENV['PACKAGE_DOWNLOAD_URL'] || 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2'
+          ENV['PHANTOMJS_DOWNLOAD_URL'] || 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2'
         end
       end
     end
@@ -114,7 +114,7 @@ module Phantomjs
         end
 
         def package_url
-          ENV['PACKAGE_DOWNLOAD_URL'] || 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2'
+          ENV['PHANTOMJS_DOWNLOAD_URL'] || 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-i686.tar.bz2'
         end
       end
     end
@@ -130,7 +130,7 @@ module Phantomjs
         end
 
         def package_url
-          ENV['PACKAGE_DOWNLOAD_URL'] || 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip'
+          ENV['PHANTOMJS_DOWNLOAD_URL'] || 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip'
         end
       end
     end


### PR DESCRIPTION
The current name of `PACKAGE_DOWNLOAD_URL` is a bit ambiguous, so changing it to `PHANTOMJS_DOWNLOAD_URL` gives a better understanding of what it is and potentially why it's set. 